### PR TITLE
Add a blog post without being authenticated.

### DIFF
--- a/blog/templates/blog/base.html
+++ b/blog/templates/blog/base.html
@@ -9,10 +9,8 @@
     </head>
     <body>
       <div class="page-header">
-        {% if user.is_authenticated %}
-          <a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
-        {% endif %}
-          <h1><a href="/">Django Girls Blog</a></h1>
+        <a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
+        <h1><a href="/">Django Girls Blog</a></h1>
       </div>
       <div class="content container">
         <div class="row">


### PR DESCRIPTION
The reason you can not see the plus button is that the user (if there is even one) is not authenticated when the Base.html file is loaded. 

You can remove the authentication so that everyone can add a blog post (not reccommended) or you can add an authenticated user. 

I added this change so that you can experiment with the authenticated user. 